### PR TITLE
[SB5-6030] upgrade illuminate/http and illluminate/validation to lara…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,8 @@ language: php
 
 matrix:
   include:
-    - php: 7.1
-      env: ILLUMINATE_VERSION=5.6.*
-    - php: 7.1
-      env: ILLUMINATE_VERSION=5.7.*
     - php: 7.2.27
-      env: ILLUMINATE_VERSION=5.6.*
-    - php: 7.2.27
-      env: ILLUMINATE_VERSION=5.7.*
+      env: ILLUMINATE_VERSION=6.11.*
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
-matrix:
-  include:
-    - php: 7.2.27
-      env: ILLUMINATE_VERSION=6.11.*
+php:
+  - 7.2
+  - 7.3
+  - 7.4
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ cache:
   directories:
     - $HOME/.composer/cache
 
-before_install:
-  - composer require "illuminate/http:6.11.*" --no-update
-  - composer require "illuminate/validation:6.11.*" --no-update
-
 before_script:
   - composer update --prefer-source --no-interaction
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ cache:
     - $HOME/.composer/cache
 
 before_install:
-  - composer require "illuminate/http:${ILLUMINATE_VERSION}" --no-update
-  - composer require "illuminate/validation:${ILLUMINATE_VERSION}" --no-update
+  - composer require "illuminate/http:6.11.*" --no-update
+  - composer require "illuminate/validation:6.11.*" --no-update
 
 before_script:
   - composer update --prefer-source --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -8,15 +8,15 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
-        "illuminate/http": "^5.6",
-        "illuminate/validation": "^5.6",
-        "soapbox/signed-requests": "^2.0.0",
+        "php": ">=7.2",
+        "illuminate/http": "^6.11",
+        "illuminate/validation": "^6.11",
+        "soapbox/signed-requests": "^3.0.0",
         "nesbot/carbon": "^1.22 || ^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0|^7.0",
-        "orchestra/testbench": "^3.6"
+        "phpunit/phpunit": "8.5.3",
+        "orchestra/testbench": "^3.9"
     },
     "autoload": {
         "psr-4": {

--- a/src/WebhookController.php
+++ b/src/WebhookController.php
@@ -2,6 +2,7 @@
 
 namespace SoapBox\Webhooks;
 
+use Illuminate\Support\Str;
 use Illuminate\Http\Response;
 
 class WebhookController
@@ -33,6 +34,6 @@ class WebhookController
      */
     private function getClass(Store $request): string
     {
-        return config('webhooks.handler_namespace') . "\\" . studly_case(str_replace('.', '_', $request->getEventType()));
+        return config('webhooks.handler_namespace') . "\\" . Str::studly(str_replace('.', '_', $request->getEventType()));
     }
 }


### PR DESCRIPTION
https://soapboxhq.atlassian.net/browse/SB5-6030

- upgrade soapbox/signed-request to v3
- upgrade illuminate/http and validation to Laravel6.11 compatible versions (hence php upgrade)
- fix failing test

These upgrades were made because this package locked down some other dependecies to specific versions and it causes upgrade Slack brain for instance fail.
